### PR TITLE
feat(backend): cria DTO entrada/saída para atividade e grupo

### DIFF
--- a/backend/src/main/java/com/ravcontrol/backend/dto/activity/request/CreateActivityRequestDTO.java
+++ b/backend/src/main/java/com/ravcontrol/backend/dto/activity/request/CreateActivityRequestDTO.java
@@ -1,0 +1,12 @@
+package com.ravcontrol.backend.dto.activity.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record CreateActivityRequestDTO(
+    @NotBlank(message = "O nome da atividade é obrigatório.")
+    String name,
+
+    @NotNull(message = "O ID do grupo é obrigatório.")
+    Long groupId
+) {}

--- a/backend/src/main/java/com/ravcontrol/backend/dto/activity/request/MoveActivityRequestDTO.java
+++ b/backend/src/main/java/com/ravcontrol/backend/dto/activity/request/MoveActivityRequestDTO.java
@@ -1,0 +1,13 @@
+package com.ravcontrol.backend.dto.activity.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+
+public record MoveActivityRequestDTO(
+    @NotNull(message = "O ID do grupo de destino é obrigatório.")
+    Long targetGroupId,
+
+    @NotNull(message = "A nova posição é obrigatória.")
+    @PositiveOrZero(message = "A posição deve ser igual ou maior que zero.")
+    Integer newPosition
+) {}

--- a/backend/src/main/java/com/ravcontrol/backend/dto/activity/request/UpdateActivityRequestDTO.java
+++ b/backend/src/main/java/com/ravcontrol/backend/dto/activity/request/UpdateActivityRequestDTO.java
@@ -1,0 +1,10 @@
+package com.ravcontrol.backend.dto.activity.request;
+
+import java.time.LocalDate;
+
+public record UpdateActivityRequestDTO(
+    String name,
+    String description,
+    LocalDate dueDate,
+    Boolean completed
+) {}

--- a/backend/src/main/java/com/ravcontrol/backend/dto/activity/response/ActivityResponseDTO.java
+++ b/backend/src/main/java/com/ravcontrol/backend/dto/activity/response/ActivityResponseDTO.java
@@ -1,0 +1,25 @@
+package com.ravcontrol.backend.dto.activity.response;
+
+import com.ravcontrol.backend.entity.Activity;
+
+import java.time.LocalDate;
+
+public record ActivityResponseDTO(
+    Long id,
+    String name,
+    String description,
+    LocalDate dueDate,
+    Boolean completed,
+    Integer position
+) {
+    public static ActivityResponseDTO fromEntity(Activity activity) {
+        return new ActivityResponseDTO(
+            activity.getId(),
+            activity.getName(),
+            activity.getDescription(),
+            activity.getDueDate(),
+            activity.getCompleted(),
+            activity.getPosition()
+        );
+    }
+}

--- a/backend/src/main/java/com/ravcontrol/backend/dto/activity/response/OverdueCountDTO.java
+++ b/backend/src/main/java/com/ravcontrol/backend/dto/activity/response/OverdueCountDTO.java
@@ -1,0 +1,5 @@
+package com.ravcontrol.backend.dto.activity.response;
+
+public record OverdueCountDTO(
+    int count
+) {}

--- a/backend/src/main/java/com/ravcontrol/backend/dto/activity/response/SearchActivityResponseDTO.java
+++ b/backend/src/main/java/com/ravcontrol/backend/dto/activity/response/SearchActivityResponseDTO.java
@@ -1,0 +1,13 @@
+package com.ravcontrol.backend.dto.activity.response;
+
+import java.time.LocalDate;
+
+public record SearchActivityResponseDTO(
+    Long id,
+    String name,
+    String description,
+    LocalDate dueDate,
+    Boolean completed,
+    Long groupId,
+    String groupName
+) {}

--- a/backend/src/main/java/com/ravcontrol/backend/dto/activityGroup/request/ActivityGroupRequestDTO.java
+++ b/backend/src/main/java/com/ravcontrol/backend/dto/activityGroup/request/ActivityGroupRequestDTO.java
@@ -1,0 +1,10 @@
+package com.ravcontrol.backend.dto.activityGroup.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record ActivityGroupRequestDTO(
+    @NotBlank(message = "O nome do grupo não pode ser vazio.")
+    @Size(max = 100, message = "O nome do grupo deve ter no máximo 100 caracteres.")
+    String name
+) {}

--- a/backend/src/main/java/com/ravcontrol/backend/dto/activityGroup/response/ActivityGroupResponseDTO.java
+++ b/backend/src/main/java/com/ravcontrol/backend/dto/activityGroup/response/ActivityGroupResponseDTO.java
@@ -1,0 +1,28 @@
+package com.ravcontrol.backend.dto.activityGroup.response;
+
+import com.ravcontrol.backend.dto.activity.response.ActivityResponseDTO;
+import com.ravcontrol.backend.entity.Activity;
+import com.ravcontrol.backend.entity.ActivityGroup;
+
+import java.util.Comparator;
+import java.util.List;
+
+public record ActivityGroupResponseDTO(
+    Long id,
+    String name,
+    List<ActivityResponseDTO> activities
+) {
+    public static ActivityGroupResponseDTO fromEntity(ActivityGroup group) {
+        List<ActivityResponseDTO> activityDtos = group.getActivities()
+            .stream()
+            .sorted(Comparator.comparing(Activity::getPosition))
+            .map(ActivityResponseDTO::fromEntity)
+            .toList();
+
+        return new ActivityGroupResponseDTO(
+            group.getId(),
+            group.getName(),
+            activityDtos
+        );
+    }
+}

--- a/backend/src/main/java/com/ravcontrol/backend/entity/Activity.java
+++ b/backend/src/main/java/com/ravcontrol/backend/entity/Activity.java
@@ -22,7 +22,7 @@ public class Activity {
     @Column(columnDefinition = "CLOB")
     private String description;
 
-    @Column(name= "due_date", nullable = false)
+    @Column(name = "due_date")
     private LocalDate dueDate;
 
     @Column(nullable = false)


### PR DESCRIPTION
Foi criado DTOs de response e request considerando os casos de uso disponibilizados. 
- ActivityRequest para mover de um grupo para outro, para atualizar informações e criar uma nova atividade. 
- ActivityResponse para controlar os dados que serão exibidos para o usuário e não correr o risco de vazar informação desnecessária para o frontend. 
- ActivityGroup Request e Response básicos para atualização e criação. 

Fixes #8 