### PR TITLE
feat(backend): cria atividade e grupo repository com crud do JPA e fu…

### DIFF
--- a/backend/src/main/java/com/ravcontrol/backend/repository/ActivityGroupRepository.java
+++ b/backend/src/main/java/com/ravcontrol/backend/repository/ActivityGroupRepository.java
@@ -1,0 +1,8 @@
+package com.ravcontrol.backend.repository;
+
+import com.ravcontrol.backend.entity.ActivityGroup;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ActivityGroupRepository  extends JpaRepository<ActivityGroup, Long> {}

--- a/backend/src/main/java/com/ravcontrol/backend/repository/ActivityRepository.java
+++ b/backend/src/main/java/com/ravcontrol/backend/repository/ActivityRepository.java
@@ -1,0 +1,26 @@
+package com.ravcontrol.backend.repository;
+
+import com.ravcontrol.backend.entity.Activity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Repository
+public interface ActivityRepository extends JpaRepository<Activity, Long> {
+
+    /**
+     * Esse método busca atividades pelo nome, contendo letras de name e ignorando case maiúscula/minúscula
+     * @param name Nome da atividade a ser buscada
+     * @return Uma lista de atividades que correspondem ao critério
+     */
+    List<Activity> findByNameContainingIgnoreCase(String name);
+
+    /**
+     * Esse método retornará a quantidade de atividades que já passaram do prazo
+     * @param today A data atual que comparará com DueDate (dueDate < today)
+     * @return A quantidade de atividades em atraso
+     */
+    int countByDueDateBeforeAndCompletedIsFalse(LocalDate today);
+}

--- a/backend/src/main/java/com/ravcontrol/backend/service/ActivityGroupService.java
+++ b/backend/src/main/java/com/ravcontrol/backend/service/ActivityGroupService.java
@@ -1,0 +1,4 @@
+package com.ravcontrol.backend.service;
+
+public class ActivityGroupService {
+}


### PR DESCRIPTION
Foi criado o repository do Activity e ActivityGroup. O JPA nos poupa muito trabalho nesses dois pois ele faz todas as funções de CRUD por trás dos panos. Porém, em ActivityRepository criamos já duas funções:
- findByNameContainingIgnoreCase
- countByDueDateBeforeCompletedIsFalse

Essas funções foram criadas pensando no caso de uso de search e notificação, porém podem ser modificadas futuramente. 

Fixes #7 