### PR TITLE
feat(service): implementa a camada de serviço para atividades e grupos.

### DIFF
--- a/backend/src/main/java/com/ravcontrol/backend/dto/activity/request/CreateActivityRequestDTO.java
+++ b/backend/src/main/java/com/ravcontrol/backend/dto/activity/request/CreateActivityRequestDTO.java
@@ -2,11 +2,15 @@ package com.ravcontrol.backend.dto.activity.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 public record CreateActivityRequestDTO(
     @NotBlank(message = "O nome da atividade é obrigatório.")
     String name,
 
     @NotNull(message = "O ID do grupo é obrigatório.")
-    Long groupId
+    Long groupId,
+
+    @Size(max = 5000, message = "A descrição não pode exceder 5000 caracteres")
+    String description
 ) {}

--- a/backend/src/main/java/com/ravcontrol/backend/entity/Activity.java
+++ b/backend/src/main/java/com/ravcontrol/backend/entity/Activity.java
@@ -113,7 +113,7 @@ public class Activity {
         this.group = group;
     }
 
-    protected void attachToGroup(ActivityGroup group, int position) {
+    public void attachToGroup(ActivityGroup group, int position) {
         this.group = group;
         this.position = position;
     }

--- a/backend/src/main/java/com/ravcontrol/backend/repository/ActivityRepository.java
+++ b/backend/src/main/java/com/ravcontrol/backend/repository/ActivityRepository.java
@@ -11,6 +11,13 @@ import java.util.List;
 public interface ActivityRepository extends JpaRepository<Activity, Long> {
 
     /**
+     * Esse método retornará o valor total de atividades do grupo
+     * @param groupId id do grupo que a atividade pertence
+     * @return retorna o valor de atividades presentes no grupo
+     */
+    int countByGroupId(Long groupId);
+
+    /**
      * Esse método busca atividades pelo nome, contendo letras de name e ignorando case maiúscula/minúscula
      * @param name Nome da atividade a ser buscada
      * @return Uma lista de atividades que correspondem ao critério

--- a/backend/src/main/java/com/ravcontrol/backend/service/ActivityGroupService.java
+++ b/backend/src/main/java/com/ravcontrol/backend/service/ActivityGroupService.java
@@ -4,6 +4,7 @@ import com.ravcontrol.backend.dto.activityGroup.request.ActivityGroupRequestDTO;
 import com.ravcontrol.backend.dto.activityGroup.response.ActivityGroupResponseDTO;
 import com.ravcontrol.backend.entity.ActivityGroup;
 import com.ravcontrol.backend.repository.ActivityGroupRepository;
+import com.ravcontrol.backend.service.exception.ResourceNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -39,10 +40,21 @@ public class ActivityGroupService {
 
     @Transactional
     public ActivityGroupResponseDTO updateGroup(Long groupId, ActivityGroupRequestDTO dto) {
-        ActivityGroup group = groupRepository.findById(groupId).orElseThrow(() -> new )
+        ActivityGroup group = groupRepository
+            .findById(groupId).
+            orElseThrow(() -> new ResourceNotFoundException("Grupo não encontrado para o ID" + groupId));
 
+        group.setName(dto.name());
+        ActivityGroup updatedGroup = groupRepository.save(group);
+
+        return ActivityGroupResponseDTO.fromEntity(updatedGroup);
     }
 
-
-
+    @Transactional
+    public void deleteGroup(Long groupId) {
+        if (!groupRepository.existsById(groupId)) {
+            throw new ResourceNotFoundException("Grupo não encontrado para o ID" + groupId);
+        }
+        groupRepository.deleteById(groupId);
+    }
 }

--- a/backend/src/main/java/com/ravcontrol/backend/service/ActivityService.java
+++ b/backend/src/main/java/com/ravcontrol/backend/service/ActivityService.java
@@ -1,0 +1,121 @@
+package com.ravcontrol.backend.service;
+
+import com.ravcontrol.backend.dto.activity.request.CreateActivityRequestDTO;
+import com.ravcontrol.backend.dto.activity.request.MoveActivityRequestDTO;
+import com.ravcontrol.backend.dto.activity.request.UpdateActivityRequestDTO;
+import com.ravcontrol.backend.dto.activity.response.ActivityResponseDTO;
+import com.ravcontrol.backend.dto.activity.response.OverdueCountDTO;
+import com.ravcontrol.backend.dto.activity.response.SearchActivityResponseDTO;
+import com.ravcontrol.backend.entity.Activity;
+import com.ravcontrol.backend.entity.ActivityGroup;
+import com.ravcontrol.backend.repository.ActivityGroupRepository;
+import com.ravcontrol.backend.repository.ActivityRepository;
+import com.ravcontrol.backend.service.exception.ResourceNotFoundException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class ActivityService {
+
+    private final ActivityRepository activityRepository;
+    private final ActivityGroupRepository groupRepository;
+
+    @Autowired
+    public ActivityService(ActivityRepository activityRepository, ActivityGroupRepository groupRepository) {
+        this.activityRepository = activityRepository;
+        this.groupRepository = groupRepository;
+    }
+
+    @Transactional
+    public ActivityResponseDTO createActivity(CreateActivityRequestDTO dto) {
+        ActivityGroup group = groupRepository
+            .findById(dto.groupId())
+            .orElseThrow(() -> new ResourceNotFoundException("Grupo não encontrado para o ID" + dto.groupId()));
+
+        int nextPosition = activityRepository.countByGroupId(group.getId());
+
+        Activity newActivity = new Activity();
+        newActivity.setName(dto.name());
+        newActivity.setDescription(dto.description());
+        newActivity.attachToGroup(group, nextPosition);
+
+        Activity savedActivity = activityRepository.save(newActivity);
+        return ActivityResponseDTO.fromEntity(savedActivity);
+    }
+
+    @Transactional
+    public ActivityResponseDTO updateActivity(Long activityId, UpdateActivityRequestDTO dto) {
+        Activity activity = activityRepository
+            .findById(activityId)
+            .orElseThrow(() -> new ResourceNotFoundException("Atividade não encontrada para o ID" + activityId));
+
+        if (dto.name() != null) {
+            activity.setName(dto.name());
+        }
+        if (dto.description() != null) {
+            activity.setDescription(dto.description());
+        }
+        if (dto.dueDate() != null) {
+            activity.setDueDate(dto.dueDate());
+        }
+        if (dto.completed() != null) {
+            activity.setCompleted(dto.completed());
+        }
+
+        Activity updatedActivity = activityRepository.save(activity);
+        return ActivityResponseDTO.fromEntity(updatedActivity);
+    }
+
+    @Transactional
+    public ActivityResponseDTO moveActivity(Long activityId, MoveActivityRequestDTO dto) {
+        Activity activity = activityRepository
+            .findById(activityId)
+            .orElseThrow(() -> new ResourceNotFoundException("Atividade não encontrada para o ID" + activityId));
+
+        ActivityGroup targetGroup = groupRepository
+            .findById(dto.targetGroupId())
+            .orElseThrow(() -> new ResourceNotFoundException("Grupo de destino não encontrado com o ID: " + dto.targetGroupId()));
+
+        activity.attachToGroup(targetGroup, dto.newPosition());
+
+        Activity movedActivity = activityRepository.save(activity);
+        return ActivityResponseDTO.fromEntity(movedActivity);
+    }
+
+    @Transactional
+    public void deleteActivity(Long activityId) {
+        if( !activityRepository.existsById(activityId)) {
+            throw new ResourceNotFoundException("Atividade não encontrada para o ID: " + activityId);
+        }
+        activityRepository.deleteById(activityId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<SearchActivityResponseDTO> searchActivities(String query) {
+        List<Activity> activities = activityRepository.findByNameContainingIgnoreCase(query);
+        return activities
+            .stream()
+            .map(activity -> new SearchActivityResponseDTO(
+                activity.getId(),
+                activity.getName(),
+                activity.getDescription(),
+                activity.getDueDate(),
+                activity.getCompleted(),
+                activity.getGroup().getId(),
+                activity.getGroup().getName()
+        ))
+            .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public OverdueCountDTO getOverdueActivitiesCount() {
+        int count = activityRepository.countByDueDateBeforeAndCompletedIsFalse(LocalDate.now());
+        return new OverdueCountDTO(count);
+    }
+}
+


### PR DESCRIPTION
## Foi implementado o serviço ActivityGroup e Activity. 
#### Activity: 
- createActivity(CreateActivityRequestDTO dto)
- updateActivity(Long activityId, UpdateActivityRequestDTO dto)
- moveActivity(Long activityId, MoveActivityRequestDTO dto)
- deleteActivity(Long activityId)
- List<SearchActivityResponseDTO> searchActivities(String query)
- getOverdueActivitiesCount()
#### ActivityGroup: 
- findAllGroups()
- createGroup(ActivityGroupRequestDTO dto)
- updateGroup(Long groupId, ActivityGroupRequestDTO dto)
- deleteGroup(Long groupId)

## Para essa implementação ser possível foi necessário refactor em:
#### CreateActivityRequestDTO:
- Adicionei String description 
#### Activity (entity) 
- Tive que mudar o método attachToGroup para público para poder usar no service
#### ActivityRepository: 
- Criação de um novo método no repositório de activity para contagem de atividades de um grupo
- Esse método foi adicionado visando a eficiência da busca desse valor inteiro para podermos definir bem a posição de uma atividade em um grupo na hora de criar uma nova

Fixes #9 