### PR TITLE
fix(backend): corrige erro de escrita de activity controller na funçã…

### DIFF
--- a/backend/src/main/java/com/ravcontrol/backend/controller/ActivityController.java
+++ b/backend/src/main/java/com/ravcontrol/backend/controller/ActivityController.java
@@ -62,7 +62,7 @@ public class ActivityController {
         return ResponseEntity.ok(count);
     }
 
-    @DeleteMapping("/{activityId")
+    @DeleteMapping("/{activityId}")
     public ResponseEntity<Void> deleteActivity(
         @PathVariable Long activityId
     ) {


### PR DESCRIPTION
Em activity controller ocorreu um erro na função de deletar no @DeleteMapping("/{activityId") . Como pode ver, estava faltando fechar as chaves e isso ocasionou em erro ao rodar o programa. 